### PR TITLE
Fix footer link target typo

### DIFF
--- a/src/Components/Footer.js
+++ b/src/Components/Footer.js
@@ -9,13 +9,13 @@ export default function Footer() {
     <div className="footer">
       <p>Hecho por Eduardo Guette </p>
       <div className="socialLogos">
-        <a target="_blanck" href="https://twitter.com/eduardoguette" className="social" >
+        <a target="_blank" href="https://twitter.com/eduardoguette" className="social" >
           <img src={logoTwitter} alt="twitter" />
         </a>
-        <a target="_blanck" href="https://instagram.com/eduardoguette" className="social" >
+        <a target="_blank" href="https://instagram.com/eduardoguette" className="social" >
           <img src={logoInstagram} alt="instagram" />
         </a>
-        <a target="_blanck" href="https://github.com/eduardoguette" className="social" >
+        <a target="_blank" href="https://github.com/eduardoguette" className="social" >
           <img src={logoGit} alt="git" />
         </a>
       </div>


### PR DESCRIPTION
## Summary
- fix `_blank` target typo for footer links

## Testing
- `npm test` *(fails: Unable to find element with the text /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_68483c79d2d4832ca918e3f35186e6b8